### PR TITLE
Allow column names beginning with digits in viz module

### DIFF
--- a/metaquantome/modules/viz.R
+++ b/metaquantome/modules/viz.R
@@ -26,7 +26,7 @@ X_AXIS_ROT <- 60
 ####### ==================== #######
 # read tab-separated file
 read_result <- function(file){
-    df <- read.delim(file, sep="\t", stringsAsFactors=FALSE)
+    df <- read.delim(file, sep="\t", stringsAsFactors=FALSE, check.names=FALSE)
     return(df)
 }
 


### PR DESCRIPTION
When `check.names` is not specified, column names are modified such that they do not start with a digit and are unique. For example:

```
> (d <- data.frame("0" = "a", "0" = "b"))
  X0 X0.1
1  a    b
```

To meet our need to use column names that begin with a digit, this PR sets `check.names=FALSE` so that an X is not prepended these names.

Additionally, because `check.names` enforces both cases, duplicates are no longer checked for. I could add a line like `names(df) <- make.unique(names(df))` to add back the duplicate enforcement, but I don't know that this is actually useful so I left it out.

I am not experienced in R, but I think this shouldn't have any other repercussions on viz.R. 