### PR TITLE
Add option to load obsolete GO terms for metaquantome expand

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,10 @@ conda config --add channels bioconda
 conda config --add channels conda-forge
 ```
 
-Then, run the following command to set up an environment named mqome, which will have metaQuantome (version 2.0.2) and all dependencies in it:
+Then, run the following command to set up an environment named mqome, which will have metaQuantome (version 2.0.3) and all dependencies in it:
 
 ```
-conda create -n mqome metaquantome=2.0.2
+conda create -n mqome metaquantome=2.0.3
 ```
 
 If the following prompt is seen at the command line, type `y`:

--- a/metaquantome/cli.py
+++ b/metaquantome/cli.py
@@ -30,7 +30,7 @@ def cli():
                pep_colname_func=args.pep_colname_func, pep_colname_tax=args.pep_colname_tax, data_dir=args.data_dir,
                outfile=args.outfile, func_file=args.func_file, func_colname=args.func_colname, ontology=args.ontology,
                slim_down=args.slim_down, tax_file=args.tax_file, tax_colname=args.tax_colname, nopep=args.nopep,
-               nopep_file=args.nopep_file, ft_tar_rank=args.ft_tar_rank)
+               nopep_file=args.nopep_file, ft_tar_rank=args.ft_tar_rank, load_obsolete_go=args.load_obsolete_go)
     elif args.command == "filter":
         run_filter(expanded_file=args.expand_file, sinfo=args.samps, ontology=args.ontology, mode=args.mode,
                    qthreshold=args.qthreshold, min_child_non_leaf=args.min_children_non_leaf,
@@ -213,6 +213,8 @@ def parse_args_cli():
     func.add_argument('--slim_down', action='store_true',
                       help='Flag. If provided, terms are mapped from the full OBO to the slim OBO. ' +
                            'Terms not in the full OBO will be skipped.')
+    func.add_argument('--load_obsolete_go', action='store_true',
+                      help='Flag. If provided, obsolete GO terms will be loaded from the database.')
     func.add_argument('--overwrite', action='store_true',
                       help='Flag. The most relevant database (GO or EC) is downloaded to data_dir, ' +
                            'overwriting any previously downloaded databases at these locations.')

--- a/metaquantome/databases/GeneOntologyDb.py
+++ b/metaquantome/databases/GeneOntologyDb.py
@@ -19,7 +19,7 @@ class GeneOntologyDb:
                      "molecular_function": 'GO:0003674',
                      "cellular_component": 'GO:0005575'}
 
-    def __init__(self, data_dir, slim_down=False):
+    def __init__(self, data_dir, slim_down=False, load_obsolete_go=False):
         """
         create GeneOntologyDb object
 
@@ -27,7 +27,7 @@ class GeneOntologyDb:
         :param slim_down: whether slim will be used in the analysis. If False, the slim db is not loaded
         (self.goslim = None)
         """
-        gofull, goslim = self._load_go_db(data_dir, slim_down)
+        gofull, goslim = self._load_go_db(data_dir, slim_down, load_obsolete_go)
         self.gofull = gofull
         self.goslim = goslim
         self.slim_down = slim_down
@@ -69,7 +69,7 @@ class GeneOntologyDb:
             stream_to_file_from_url(SLIM_OBO_URL, slim_path)
 
     @staticmethod
-    def _load_go_db(data_dir, slim_down):
+    def _load_go_db(data_dir, slim_down, load_obsolete_go):
         """
         Load GO databases using goatools.oboparser. Always
         loads the full GO, and loads the metagenomics slim GO if slim_down = True
@@ -83,9 +83,9 @@ class GeneOntologyDb:
             logging.error('GO files not found in specified directory.\n' +
                           'Please use the command >metaquantome db ...  to download the files.')
         # read gos
-        go_dag = obo_parser.GODag(obo_path)
+        go_dag = obo_parser.GODag(obo_path, load_obsolete=load_obsolete_go)
         if slim_down:
-            go_dag_slim = obo_parser.GODag(slim_path)
+            go_dag_slim = obo_parser.GODag(slim_path, load_obsolete=load_obsolete_go)
         else:
             go_dag_slim = None
         return go_dag, go_dag_slim

--- a/metaquantome/modules/expand.py
+++ b/metaquantome/modules/expand.py
@@ -10,7 +10,7 @@ from metaquantome.classes.SampleGroups import SampleGroups
 
 def expand(mode, sinfo, int_file, pep_colname_int, pep_colname_func, pep_colname_tax, data_dir=None, outfile=None,
            func_file=None, func_colname=None, ontology='go', slim_down=False, tax_file=None, tax_colname=None,
-           nopep=False, nopep_file=None, ft_tar_rank='genus'):
+           nopep=False, nopep_file=None, ft_tar_rank='genus', load_obsolete_go=False):
     """
     Expand the directly annotated hierarchy to one with all ancestors.
 
@@ -31,6 +31,7 @@ def expand(mode, sinfo, int_file, pep_colname_int, pep_colname_func, pep_colname
     :param nopep_file: path to file without peptides
     :param data_dir: path to parent directory of database files
     :param ft_tar_rank: in ft mode, all taxonomy are mapped to this rank if possible.
+    :param load_obsolete_go: Boolean. Whether to load obsolete GO terms.
     :return: returns a dataframe of functional or taxonomic terms with associated intensities.
     Missing values are represented as 0.
     """
@@ -50,13 +51,14 @@ def expand(mode, sinfo, int_file, pep_colname_int, pep_colname_func, pep_colname
     # run modules based on modes
     if mode == 'f':
         results = functional_analysis(df=df, func_colname=func_colname, samp_grps=samp_grps, ontology=ontology,
-                                      slim_down=slim_down, data_dir=data_dir)
+                                      slim_down=slim_down, data_dir=data_dir, load_obsolete_go=load_obsolete_go)
     elif mode == 't':
         results = taxonomy_analysis(df=df, samp_grps=samp_grps, data_dir=data_dir, tax_colname=tax_colname)
     elif mode == 'ft':
         results = function_taxonomy_analysis(df=df, func_colname=func_colname, pep_colname=pep_colname_int,
                                              ontology=ontology, slim_down=slim_down, tax_colname=tax_colname,
-                                             samp_grps=samp_grps, ft_tar_rank=ft_tar_rank, data_dir=data_dir)
+                                             samp_grps=samp_grps, ft_tar_rank=ft_tar_rank, data_dir=data_dir,
+                                             load_obsolete_go=load_obsolete_go)
     else:
         raise ValueError('Invalid mode. Expected one of "f", "t", or "ft"')
 

--- a/metaquantome/modules/function_taxonomy_interaction.py
+++ b/metaquantome/modules/function_taxonomy_interaction.py
@@ -7,7 +7,7 @@ from metaquantome.databases.NCBITaxonomyDb import NCBITaxonomyDb
 
 
 def function_taxonomy_analysis(df, func_colname, pep_colname, ontology, slim_down, tax_colname, samp_grps, ft_tar_rank,
-                               data_dir):
+                               data_dir, load_obsolete_go):
     # todo: add normalization module for ft modules
     # choose bp, cc, or mf
     # don't return bp, cc, or mf themselves
@@ -38,7 +38,7 @@ def function_taxonomy_analysis(df, func_colname, pep_colname, ontology, slim_dow
         ValueError('ontology must be "go" for function-taxonomy modules')
 
     # ---- reduce, normalize, (optionally) slim ---- #
-    godb, norm_df = fa.clean_function_df(data_dir, df, func_colname, ontology, slim_down)
+    godb, norm_df = fa.clean_function_df(data_dir, df, func_colname, ontology, slim_down, load_obsolete_go)
     if slim_down:
         norm_df = fa.slim_down_df(godb, norm_df, func_colname)
     # remove peptide/go-term duplicates (in the case that different GO term annotations

--- a/metaquantome/modules/functional_analysis.py
+++ b/metaquantome/modules/functional_analysis.py
@@ -6,7 +6,7 @@ import metaquantome.databases.EnzymeDb as ec
 from metaquantome.util import utils
 
 
-def functional_analysis(df, func_colname, samp_grps, ontology, slim_down, data_dir):
+def functional_analysis(df, func_colname, samp_grps, ontology, slim_down, data_dir, load_obsolete_go):
     """
     Expand functional terms and aggregate intensities.
 
@@ -17,10 +17,11 @@ def functional_analysis(df, func_colname, samp_grps, ontology, slim_down, data_d
     :param ontology: Functional ontology. Either 'go', 'ec', or 'cog'
     :param slim_down: Boolean. Whether to map terms to slim or not.
     :param data_dir: Directory to contain functional database files (ex. go-basic.obo)
+    :param load_obsolete_go: Boolean. Whether to load obsolete GO terms.
     :return: A dataframe with a functional term and its associated sample-specific intensity in each
     row
     """
-    db, norm_df = clean_function_df(data_dir, df, func_colname, ontology, slim_down)
+    db, norm_df = clean_function_df(data_dir, df, func_colname, ontology, slim_down, load_obsolete_go)
 
     if ontology == "go":
         # filter to only those in full GO and non-missing
@@ -78,7 +79,7 @@ def slim_down_df(godb, df_clean, go_colname):
     return df_loc
 
 
-def clean_function_df(data_dir, df, func_colname, ontology, slim_down):
+def clean_function_df(data_dir, df, func_colname, ontology, slim_down, load_obsolete_go):
     """
     make functional terms nonredundant and normalize dataframe so there's only one functional
     term per row
@@ -97,7 +98,7 @@ def clean_function_df(data_dir, df, func_colname, ontology, slim_down):
     db = None
     if ontology in {"go", "ec"}:
         if ontology == "go":
-            db = GeneOntologyDb(data_dir, slim_down)
+            db = GeneOntologyDb(data_dir, slim_down, load_obsolete_go)
         elif ontology == "ec":
             db = ec.EnzymeDb(data_dir)
         # reduce df to non-redundant functional terms

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 
-VERSION = '2.0.2'
+VERSION = '2.0.3'
 URL = 'https://github.com/galaxyproteomics/metaquantome'
 AUTHOR = 'Caleb Easterly'
 AUTHOR_EMAIL = 'caleb.easterly@gmail.com'


### PR DESCRIPTION
This adds an option for the user to allow obsolete GO terms to be loaded from the input GO database.

It simply passes the option to `load_obsolete` of `GODag`. See https://github.com/tanghaibao/goatools/issues/153#issuecomment-588404484.