### PR TITLE
Update metaQuantome for newer dependencies and databases

### DIFF
--- a/metaquantome/cli.py
+++ b/metaquantome/cli.py
@@ -2,7 +2,7 @@ import sys
 import argparse
 import logging
 import os
-import pkg_resources
+import importlib.metadata
 
 # add metaquantome parent directory to path
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
@@ -99,7 +99,7 @@ def parse_args_cli():
             "Any issues can be brought to attention here: https://github.com/galaxyproteomics/metaquantome/issues."
     )
     parser.add_argument('-v', '--version', action='version',
-                         version=pkg_resources.require("metaquantome")[0].version)
+                         version=importlib.metadata.version('metaquantome'))
 
     # split this into three submodules
     subparsers = parser.add_subparsers(title="commands", dest="command")

--- a/metaquantome/databases/EnzymeDb.py
+++ b/metaquantome/databases/EnzymeDb.py
@@ -54,9 +54,9 @@ class EnzymeDb:
             logging.info('Using ENZYME files in ' + data_dir)
         else:
             logging.info('Downloading enzyme files from ftp.expasy.org to ' + data_dir)
-            enz_dat_url = 'ftp://ftp.expasy.org/databases/enzyme/enzyme.dat'
+            enz_dat_url = 'https://ftp.expasy.org/databases/enzyme/enzyme.dat'
             stream_to_file_from_url(enz_dat_url, dat_path)
-            enz_class_url = 'ftp://ftp.expasy.org/databases/enzyme/enzclass.txt'
+            enz_class_url = 'https://ftp.expasy.org/databases/enzyme/enzclass.txt'
             stream_to_file_from_url(enz_class_url, class_path)
             # create a simpler file from enzyme.dat
             EnzymeDb._create_ec_num_enzyme_name_association_file(dat_path, dat_json)

--- a/metaquantome/databases/GeneOntologyDb.py
+++ b/metaquantome/databases/GeneOntologyDb.py
@@ -4,8 +4,8 @@ import logging
 
 from metaquantome.util.utils import safe_cast_to_list, stream_to_file_from_url
 
-FULL_OBO_URL = 'http://purl.obolibrary.org/obo/go/go-basic.obo'
-SLIM_OBO_URL = 'http://current.geneontology.org/ontology/subsets/goslim_metagenomics.obo'
+FULL_OBO_URL = 'https://current.geneontology.org/ontology/go-basic.obo'
+SLIM_OBO_URL = 'https://current.geneontology.org/ontology/subsets/goslim_metagenomics.obo'
 
 
 class GeneOntologyDb:

--- a/metaquantome/databases/NCBITaxonomyDb.py
+++ b/metaquantome/databases/NCBITaxonomyDb.py
@@ -16,6 +16,7 @@ BASIC_TAXONOMY_TREE = ["phylum",
 # taxonomy tree (in order) with the full ranks as returned by Unipept
 # this should capture most of the ranks from most software
 FULL_TAXONOMY_TREE = ['no rank',
+                      'domain',
                       'superkingdom', 'kingdom', 'subkingdom',
                       'superphylum', 'phylum', 'subphylum',
                       'superclass', 'class', 'subclass', 'infraclass',

--- a/metaquantome/modules/function_taxonomy_interaction.py
+++ b/metaquantome/modules/function_taxonomy_interaction.py
@@ -72,7 +72,7 @@ def function_taxonomy_analysis(df, func_colname, pep_colname, ontology, slim_dow
     # select columns for adding purposes
     df_int = dedup_df[samp_grps.all_intcols + [func_colname, 'des_rank']]
     # do counts
-    df_counts = df_int.copy()
+    df_counts = df_int.copy().astype('object')
     df_counts.loc[:, samp_grps.all_intcols] = df_counts.loc[:, samp_grps.all_intcols] > 0
     # group by both cog and lca and add
     grouped = df_int.groupby(by=[func_colname, 'des_rank']).sum()

--- a/metaquantome/modules/stat.py
+++ b/metaquantome/modules/stat.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pandas as pd
 from scipy import stats as sps
 from statsmodels.sandbox.stats import multicomp as mc
 
@@ -91,8 +92,8 @@ def test_norm_intensity(df, samp_grps, paired, parametric):
     # test, using logged df
     if parametric:
         # don't need to split into paired/unpaired, because both are available in ttest_ind
-        test_results = test_df.apply(lambda x: sps.stats.ttest_ind(x[grp1_intcols].dropna(),
-                                                                   x[grp2_intcols].dropna(),
+        test_results = test_df.apply(lambda x: sps.ttest_ind(pd.to_numeric(x[grp1_intcols].dropna()),
+                                                                   pd.to_numeric(x[grp2_intcols].dropna()),
                                                                    equal_var=paired).pvalue,
                                      axis=1)
     else:

--- a/metaquantome/modules/viz.R
+++ b/metaquantome/modules/viz.R
@@ -445,7 +445,7 @@ prcomp_cli <- function(args){
     strip <- args[9]
     mq_prcomp(img=img, df=df, all_intcols=all_intcols, json_dump=json_dump,
         colors=colors, calculate_sep=calculate_sep, width=width, height=height,
-        strip=strip, infilename)
+        strip=strip, infilename=infilename)
 }
 
 

--- a/metaquantome/modules/viz.R
+++ b/metaquantome/modules/viz.R
@@ -472,7 +472,7 @@ mq_volcano <- function(df, img, fc_name, fc_corr_p, flip_fc, gosplit, width, hei
     xmin <- min(df$fc) * 1.2
     ymax <- max(df$neglog10p) * 1.2
     ymin <- 0
-    volcano_colors <- scale_color_manual(values = c("grey50", "seagreen3"), guide=FALSE)
+    volcano_colors <- scale_color_manual(values = c("grey50", "seagreen3"), guide="none")
     if (gosplit){
         vplt <- ggplot(df, aes(x = fc, y = neglog10p)) +
             geom_point(aes(color = de)) +

--- a/metaquantome/util/utils.py
+++ b/metaquantome/util/utils.py
@@ -19,7 +19,9 @@ def stream_to_file_from_url(url, tar):
     :param tar: target local file
     :return: None
     """
-    f = request.urlopen(url)
+    version = importlib.metadata.version('metaquantome')
+    req = request.Request(url, headers={'User-Agent': f'metaQuantome/{version}'})
+    f = request.urlopen(req)
     data = f.read()
     with open(tar, 'wb') as tarfile:
         tarfile.write(data)

--- a/metaquantome/util/utils.py
+++ b/metaquantome/util/utils.py
@@ -1,9 +1,9 @@
 import re
-import pkg_resources
+import importlib.resources
 import os
 from urllib import request
 
-BASE_DIR = pkg_resources.resource_filename('metaquantome', '/')
+BASE_DIR = importlib.resources.files('metaquantome')
 DATA_DIR = os.path.join(BASE_DIR, 'data')
 MISSING_VALUES = ["", "0", "NA", "NaN", "0.0"]
 ONTOLOGIES = ['cog', 'go', 'ec']

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,8 @@ setup(
         'goatools',
         'numpy',
         'statsmodels',
-        'biopython'
+        'biopython',
+        'legacy-cgi'
     ],
     python_requires='>=3.10',
     entry_points={

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 
-VERSION = '2.0.3'
+VERSION = '2.0.4'
 URL = 'https://github.com/galaxyproteomics/metaquantome'
 AUTHOR = 'Caleb Easterly'
 AUTHOR_EMAIL = 'caleb.easterly@gmail.com'
@@ -32,7 +32,7 @@ setup(
         'statsmodels',
         'biopython'
     ],
-    python_requires='>=3.5',
+    python_requires='>=3.10',
     entry_points={
         'console_scripts': ['metaquantome=metaquantome.cli:cli'],
     },

--- a/tests/notravis/testDownloads.py
+++ b/tests/notravis/testDownloads.py
@@ -22,7 +22,7 @@ class TestDownloads(unittest.TestCase):
                 self.assertTrue(os.path.exists(content))
             # make sure parsed correctly
             # this is from enzyme.dat
-            self.assertEqual(enzyme_db.ecdb['1.2.3.4']['descript'], 'Oxalate oxidase.')
+            self.assertEqual(enzyme_db.ecdb['1.2.3.4']['descript'], 'oxalate oxidase.')
 
             # from enzclass.txt
             self.assertEqual(enzyme_db.ecdb['6.1.-.-']['descript'], 'Forming carbon-oxygen bonds.')

--- a/tests/travis/testExpand.py
+++ b/tests/travis/testExpand.py
@@ -151,14 +151,14 @@ class TestTaxonomyAnalysisExpand(unittest.TestCase):
         tax_df = expand.expand('t', sinfo='{"s1": ["int1", "int2", "int3"]}', int_file=int, pep_colname_int='peptide',
                                pep_colname_func='peptide', pep_colname_tax='peptide', data_dir=TEST_DIR, tax_file=tax,
                                tax_colname='lca')
-        self.assertEqual(tax_df.query("rank == 'phylum' and taxon_name == 'Proteobacteria'")['int3'].values[0], np.log2(70))
+        self.assertEqual(tax_df.query("rank == 'phylum' and taxon_name == 'Campylobacterota'")['int3'].values[0], np.log2(70))
 
     def testNopep(self):
         nopep=testfile('nopep.tab')
         tax_df = expand.expand('t', sinfo='{"s1": ["int1", "int2", "int3"]}', int_file=None, pep_colname_int='peptide',
                                pep_colname_func='peptide', pep_colname_tax='peptide', data_dir=TEST_DIR, tax_colname='lca',
                                nopep=True, nopep_file=nopep)
-        self.assertEqual(tax_df.query("rank == 'phylum' and taxon_name == 'Proteobacteria'")['int3'].values[0],
+        self.assertEqual(tax_df.query("rank == 'phylum' and taxon_name == 'Campylobacterota'")['int3'].values[0],
                          np.log2(70))
 
     def testParentIntensityHigher(self):

--- a/tests/travis/testIO.py
+++ b/tests/travis/testIO.py
@@ -13,7 +13,7 @@ class TestIO(unittest.TestCase):
         taxin = os.path.join(DATA_DIR, 'test', 'unipept_a_thaliana_result_w_pep.tab')
         df = metaquantome.util.expand_io.read_taxonomy_table(taxin, 'peptide', 'lca')
         # the first peptide is assigned to 'root'
-        self.assertEqual(df['lca'][0], 'root')
+        self.assertEqual(df['lca'].iloc[0], 'root')
 
     def testFunctionIn(self):
         funcin = os.path.join(DATA_DIR, 'test', 'multiple_func.tab')

--- a/tests/travis/testNCBITaxonomyDb.py
+++ b/tests/travis/testNCBITaxonomyDb.py
@@ -45,7 +45,7 @@ class TestTaxonomyDatabase(unittest.TestCase):
     def testGetRank(self):
         testid = 2
         rank = self.ncbi.get_rank(testid)
-        self.assertEqual(rank, 'superkingdom')
+        self.assertEqual(rank, 'domain')
 
     def testGetChildren(self):
         # test case is the family hominidae
@@ -61,10 +61,13 @@ class TestTaxonomyDatabase(unittest.TestCase):
         # gorilla species (499232, 9593)
         # homo species (1425170, 9606, 2665953)
         # pan species (9597, 9598)
-        # and pongo species (9601, 502961, 9600, 2051901, 9603)
+        # pongo species (9601, 502961, 9600, 2051901, 9603)
+        # undescribed hominidae, pan, and homo species (2922388, 3612878, 2813599)
+        # homo sapiens x pan troglodytes (2883641)
         descendants_exp = {9592, 9605, 9599, 9596, 499232, 9593,
                            1425170, 9606, 9597, 9598,
-                           9601, 502961, 9600, 2051901, 9603, 2665953}
+                           9601, 502961, 9600, 2051901, 9603, 2665953,
+                           2922388, 3612878, 2813599, 2883641}
         self.assertSetEqual(self.ncbi.get_descendants(id), descendants_exp)
 
     def testGetParents(self):

--- a/tests/travis/testStat.py
+++ b/tests/travis/testStat.py
@@ -113,7 +113,7 @@ class TestTaxonomyAnalysisTest(unittest.TestCase):
         self.assertTrue(tax_tst['p_s1_over_s2'][210] > 0.05)
         self.assertTrue(tax_tst['p_s1_over_s2'][[1496,1870884]].le(0.05).all())
         # also, make sure firmicutes phylum is sum of c difficile and clostridiaceae
-        self.assertEqual(tax_tst['int1'][1239], np.log2(1020))
+        self.assertTrue(np.isclose(tax_tst['int1'][1239], np.log2(1020), rtol=0, atol=1e-14))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This makes a variety of updates that will allow metaQuantome to run with newer Python versions and libraries, as well as brings unit tests passing with the latest database downloads.

Changes to metaQuantome include:
- Add "domain" rank to `NCBITaxonomyDb.py`.
- Convert `grp1_intcols` and `grp2_intcols` to dtype float64 as required by `sps.ttest_ind()`.
- Use guide="none" in scale_color_manual, as guide=FALSE is deprecated.
- Use custom User-Agent as geneontology.org blocks `urllib` default `User-Agent`.
- Add `legacy-cgi` to `install_requires` in `setup.py` as it's needed by `ete3`, but removed from standard library in Python 3.13
- Create `df_counts` copy from `df_ints` as type `object` s.t. floats may be replaced with booleans.
- Replace deprecated 'pkg_resources' with `importlib`
- Increase Python version in setup.py to >=3.10.
- Use iloc instead of direct indexing of Series.

Additionally, the following changes were made to automated tests:
- Change capitalization
- Add further descendants of Hominidae (taxid=9604)
- Account for floating point rounding error when reading in floats from `expand_taxttest.tab` by using np.isclose().
- Assert rank for Bacteria (taxid=2) is "domain"
- Replace Proteobacteria with Campylobacterota phylum now expected in taxa database.